### PR TITLE
better responsive layout

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,5 +31,9 @@ dominic tarr
 piet geursen
 mix irving 
 
-<img class='signature' src='radiolarians.jpeg' />
+contact@protozoa.nz
+
+</section>
+
+
 

--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@
 }
 
 body {
+  background: url("radiolarians.jpeg") no-repeat;
   background-color: #151515;
   color: rgba(255, 255, 255, .9);
   font-family: Cardo, "Helvetica Neue", Helvetica, Arial, sans-serif;


### PR DESCRIPTION
make image a css-background, to kill unnecessary horizontal scrollbar on narrow devices.

![screen shot 2017-03-20 at 13 34 47](https://cloud.githubusercontent.com/assets/259374/24086336/ab5ba392-0d72-11e7-9217-4d5db33c24c6.png)

before, this could happen (used shutter for this screen shot, because the dev tools in FF doesn't show the scroll bar.
![protozoa-nz_unresponsive](https://cloud.githubusercontent.com/assets/259374/24086364/248980cc-0d73-11e7-9f9e-9d5d0b833680.png)
